### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 anyio==3.6.2
 APScheduler==3.10.0
 asyncio==3.4.3
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 certifi==2022.12.7
 EdgeGPT==0.0.51
 h11==0.14.0


### PR DESCRIPTION
fixed build failed
Failed to build backports.zoneinfo ERROR: Could not build wheels for backports.zoneinfo which use PEP 517 and cannot be installed directly